### PR TITLE
Bug/stale_completed_tasks

### DIFF
--- a/models/marts/core/fact_todos.sql
+++ b/models/marts/core/fact_todos.sql
@@ -4,7 +4,10 @@
     unique_key = ['todo_lookahead_skey'],
     incremental_strategy = 'merge',
     on_schema_change='append_new_columns',
-    pre_hook = ['{{cleanup_nulls("todo_id")}}']
+    pre_hook = ['{{cleanup_nulls("todo_id")}}'],
+    post_hook = ["{% if not is_incremental() %} {{ setup_textsearch() }} {% endif %}"]
+
+    
 ) }}
 WITH source AS (
     SELECT
@@ -24,4 +27,3 @@ FROM
 OR
   todo_modifiedtime IS NULL
 {% endif %}
-

--- a/models/staging/stg_todos.sql
+++ b/models/staging/stg_todos.sql
@@ -262,7 +262,7 @@ FROM
 
 {% if is_incremental() %}
   WHERE 
-  todo_modifiedtime >= (select coalesce(max(todo_modifiedtime),'1900-01-01 00:00:00') from {{ this }} )
+  todo_completedtime >= todo_modifiedtime -- address this bug tasks completed dont get updated in modified time
   OR
-  todo_modifiedtime IS NULL
+  todo_modifiedtime >= (select coalesce(max(todo_modifiedtime),'1900-01-01 00:00:00') from {{ this }} )
 {% endif %}


### PR DESCRIPTION
<!---

Provide a short summary in the Title above. Examples of good PR titles:

* "Feature: add so-and-so models"

* "Fix: deduplicate such-and-such"

* "Update: dbt version 0.13.0"

-->

## Description & motivation

this PR patches the issue with ticktick API that don't update `todo_modifiedtime` when a task is completed; only `todo_completedtime` is updated instead. Some observations
- confirmed that the completed tasks are loaded to `base_todos`
- those completed tasks don't get modifiedtime updated.
- the fix used was, to add into `fact_todos` another incremental condition that loads upstream row with `todo_completedtime` > `todo_modifiedtime`







also sets up macro `setup_textsearch` as a post_hook for `fact_todos` that only triggers in a full refresh. 


