### PR TITLE
incremental todos : full refresh for recurring tasks

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -14,8 +14,8 @@
     "python.venvFolders": [
         "${workspaceFolder}/.venv"
     ],
-    "python.envFile": "${workspaceFolder}/.env",
-    "python.defaultInterpreterPath": "${workspaceFolder}/.venv/bin/python",
+    "python.envFile": "${workspaceFolder}/../.env",
+    "python.defaultInterpreterPath": "${workspaceFolder}/../.venv/bin/python",
 
     "python.terminal.activateEnvironment": true,
     "terminal.integrated.inheritEnv": true,
@@ -27,7 +27,7 @@
         "/**/.github/**/*.yml": "github-actions-workflow"
     },
     "terminal.integrated.environmentChangesRelaunch": true,
-    "dbt.dbtPythonPathOverride": "${workspaceFolder}/.venv/bin/python",
+    "dbt.dbtPythonPathOverride": "${workspaceFolder}/../.venv/bin/python",
 
 
     

--- a/models/marts/core/fact_todos.sql
+++ b/models/marts/core/fact_todos.sql
@@ -23,7 +23,8 @@ FROM
     source
 
 {% if is_incremental() %}
-  WHERE  todo_modifiedtime >= (select coalesce(max(todo_modifiedtime),'1900-01-01 00:00:00') from {{ this }} )
-OR
+  WHERE 
+  _modified_time >= (select coalesce(max(_modified_time),'1900-01-01 00:00:00') from {{ this }} )
+  OR
   todo_modifiedtime IS NULL
 {% endif %}


### PR DESCRIPTION
<!---

Provide a short summary in the Title above. Examples of good PR titles:

* "Feature: add so-and-so models"

* "Fix: deduplicate such-and-such"

* "Update: dbt version 0.13.0"

-->

## Description & motivation

<!---

Describe your changes, and why you're making them. Is this linked to an open

issue, a Trello card, or another pull request? Link it here.

-->

Patches #2 where I missed a logic for incremental model `stg_todo` : **all recurring tasks should be full refresh** to account for the habit bucket logic windowing over all instances of the repeat task.
Else will break lightdash habit tracker cause the col `habit_bucket` is stale.

